### PR TITLE
Allow parameter initialization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -29,6 +29,17 @@ The sampler is constructed using
 ```julia
 spl = MetropolisHastings(proposal)
 ```
+
+When using `MetropolisHastings` with the function `sample`, the following keyword
+arguments are allowed:
+
+- `init_params` defines the initial parameterization for your model. If
+none is given, the initial parameters will be drawn from the sampler's proposals.
+- `param_names` is a vector of strings to be assigned to parameters. This is only
+used if `chain_type=Chains`.
+- `chain_type` is the type of chain you would like returned to you. Supported
+types are `chain_type=Chains` if `MCMCChains` is imported, or 
+`chain_type=StructArray` if `StructArrays` is imported.
 """
 mutable struct MetropolisHastings{D} <: Metropolis
     proposal :: D

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -155,9 +155,14 @@ function step!(
     model::DensityModel,
     spl::MetropolisHastings,
     N::Integer;
+    init_params=nothing,
     kwargs...
 )
-    return propose(spl, model)
+    if init_params === nothing
+        return propose(spl, model)
+    else
+        return Transition(model, init_params)
+    end
 end
 
 # Define the other step functions. Returns a Transition containing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,5 +78,17 @@ using MCMCChains
         c3 = sample(m3, MetropolisHastings(p3), 100; chain_type=Vector{NamedTuple})
         c4 = sample(m4, MetropolisHastings(p4), 100; chain_type=Vector{NamedTuple})
     end
+
+    @testset "Initial parameters" begin
+        # Set up our sampler with initial parameters.
+        spl1 = StaticMH([Normal(0,1), Normal(0, 1)])
+
+        val = [0.4, 1.2]
+
+        # Sample from the posterior.
+        chain1 = sample(model, spl1, 10, init_params = val)
+
+        @test chain1[1].params == val
+    end
 end
 


### PR DESCRIPTION
You can now pass `initial_params=something` to `sample`, and AdvancedMH will begin sampling from that point. The code assumes the user has matched the "shape" of the proposal, be it vector, univariate, or NamedTuple.