### PR TITLE
Small fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,23 +6,18 @@ version = "0.3.1"
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 AbstractMCMC = "0.3"
 Distributions = "0.20, 0.21, 0.22, 0.23"
-Reexport = "0.2"
 Requires = "1.0"
-StructArrays = "^0"
 julia = "1"
 
 [extras]
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StructArrays", "MCMCChains"]
+test = ["StructArrays", "MCMCChains", "Test"]

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -60,11 +60,12 @@ function bundle_samples(
     rng::AbstractRNG, 
     model::DensityModel, 
     s::Metropolis, 
-    N::Integer, 
-    ts::Type{Any}; 
+    N::Integer,
+    ts::Vector{<:AbstractTransition},
+    chain_type::Type{Any}; 
     param_names=missing,
     kwargs...
-) where {ModelType<:AbstractModel, T<:AbstractTransition}
+)
     return ts
 end
 
@@ -73,11 +74,11 @@ function bundle_samples(
     model::DensityModel, 
     s::Metropolis, 
     N::Integer, 
-    ts::Vector{T},
+    ts::Vector{<:AbstractTransition},
     chain_type::Type{Vector{NamedTuple}}; 
     param_names=missing,
     kwargs...
-) where {ModelType<:AbstractModel, T<:AbstractTransition}
+)
     # Check if we received any parameter names.
     if ismissing(param_names)
         param_names = ["param_$i" for i in 1:length(keys(ts[1].params))]

--- a/src/mcmcchains-connect.jl
+++ b/src/mcmcchains-connect.jl
@@ -6,11 +6,11 @@ function bundle_samples(
     model::DensityModel, 
     s::Metropolis, 
     N::Integer, 
-    ts::Vector{T},
+    ts::Vector{<:AbstractTransition},
     chain_type::Type{Chains}; 
     param_names=missing,
     kwargs...
-) where {ModelType<:AbstractModel, T<:AbstractTransition}
+)
     # Turn all the transitions into a vector-of-vectors.
     vals = copy(reduce(hcat,[vcat(t.params, t.lp) for t in ts])')
 

--- a/src/structarray-connect.jl
+++ b/src/structarray-connect.jl
@@ -1,4 +1,4 @@
-using StructArrays
+import .StructArrays: StructArray
 
 # A basic chains constructor that works with the Transition struct we defined.
 function bundle_samples(

--- a/src/structarray-connect.jl
+++ b/src/structarray-connect.jl
@@ -6,11 +6,11 @@ function bundle_samples(
     model::DensityModel, 
     s::Metropolis, 
     N::Integer, 
-    ts::Vector{T},
+    ts::Vector{<:AbstractTransition},
     chain_type::Type{StructArray}; 
     param_names=missing,
     kwargs...
-) where {ModelType<:AbstractModel, T<:AbstractTransition}
+)
     return StructArray(bundle_samples(rng, model, s, N, ts, Vector{NamedTuple}; param_names=param_names, kwargs...))
 end
 

--- a/src/structarray-connect.jl
+++ b/src/structarray-connect.jl
@@ -14,4 +14,4 @@ function bundle_samples(
     return StructArray(bundle_samples(rng, model, s, N, ts, Vector{NamedTuple}; param_names=param_names, kwargs...))
 end
 
-AbstractMCMC.chainscat(cs::StructArray...) = [cs[i] for i in 1:length(cs)]
+AbstractMCMC.chainscat(c::StructArray, cs::StructArray...) = vcat(c, cs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,10 @@
-using Test
 using AdvancedMH
-using Random
 using Distributions
-using Random
 using StructArrays
 using MCMCChains
+
+using Random
+using Test
 
 @testset "AdvancedMH" begin
     # Set a seed


### PR DESCRIPTION
A bunch of fixes: cleaning dependencies and imports, removing unused type parameters, and avoiding invalidating the default definition of `chainscat`.