### PR TITLE
Update Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.3.1"
+version = "0.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"


### PR DESCRIPTION
Turing's update to AbstractMCMC 0.4 requires a new release of AdvancedMH that supports AbstractMCMC 0.4.