### PR TITLE
[WIP] Add affine-invariant ensemble sampler

### DIFF
--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -102,5 +102,6 @@ end
 # Include inference methods.
 include("proposal.jl")
 include("mh-core.jl")
+include("emcee.jl")
 
 end # module AdvancedMH

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -93,7 +93,6 @@ function propose(
         end
     end
 
-    # display([walkers new_walkers])
     return vals
 end
 

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -81,7 +81,6 @@ function propose(
     vals = map(interval) do k
         xk = walkers[k]
         xj = walkers[rand(filter(z -> z != k, interval))]
-        xj = walkers[rand(filter(z -> z != k, interval))]
         z = zs[k]
         y = xk.params + z .* (xj.params - xk.params)
         new_params = Transition(model, y)

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -1,0 +1,108 @@
+
+
+struct EmceeTransition{T<:Transition}
+    walkers :: Vector{T}
+end
+
+mutable struct Emcee{F<:Real} <: ProposalStyle
+    stretch_size :: F
+    num_walkers :: Int
+end
+
+function AbstractMCMC.step!(
+    rng::AbstractRNG,
+    model::DensityModel,
+    spl::MetropolisHastings,
+    ::Integer,
+    params_prev::EmceeTransition;
+    kwargs...
+)
+    # Generate a new proposal.
+    params = propose(spl, model, params_prev)
+    return params
+end
+
+# Make a proposal from a distribution.
+function propose(
+    spl::MetropolisHastings{<:Proposal{<:Emcee}},
+    model::DensityModel
+)
+    proposal = propose(spl.proposal, model)
+    return EmceeTransition(map(p -> Transition(model, p), proposal))
+end
+
+function propose(
+    spl::MetropolisHastings{<:Proposal{<:Emcee}},
+    model::DensityModel,
+    t
+)
+    proposal = propose(spl.proposal, model, t)
+    return EmceeTransition(proposal)
+end
+
+function propose(
+    proposal::Proposal{<:Emcee, <:Distribution}, 
+    model::DensityModel
+)
+    g = map(i -> rand(proposal), 1:proposal.type.num_walkers)
+    return g
+end
+
+function propose(
+    proposal::Proposal{<:Emcee, <:AbstractArray{T, 2}}, 
+    model::DensityModel
+) where T
+    size(proposal.proposal, 2) == proposal.type.num_walkers || 
+        error("""Initial matrix must have n_walkers ($(proposal.type.num_walkers)) columns.
+        Provided matrix has $(size(proposal.proposal, 2)) columns.""")
+    return map(i -> proposal.proposal[:, i], 1:size(proposal.proposal, 2))
+end
+
+function q(
+    proposal::Proposal{<:Emcee, <:Distribution}, 
+    t,
+    t_cond
+)
+    return sum(logpdf(proposal, t.params - t_cond.params))
+end
+
+function propose(
+    proposal::Proposal{<:Emcee}, 
+    model::DensityModel,
+    t
+)
+    walkers = t.walkers
+    ns = length(walkers[1].params)
+    zs = ((proposal.type.stretch_size - 1.0) .* rand(proposal.type.num_walkers) .+ 1) .^ 2.0 ./ proposal.type.stretch_size
+    interval = collect(1:proposal.type.num_walkers)
+    partition = interval[1:div(proposal.type.num_walkers, 2)]
+    alphamult = (ns - 1) .* log.(zs)
+
+    vals = map(interval) do k
+        xk = walkers[k]
+        xj = walkers[rand(filter(z -> z != k, interval))]
+        xj = walkers[rand(filter(z -> z != k, interval))]
+        z = zs[k]
+        y = xk.params + z .* (xj.params - xk.params)
+        new_params = Transition(model, y)
+        alpha = alphamult[k] + new_params.lp - xk.lp + q(proposal, xk, new_params) - q(proposal, new_params, xk)
+
+        if alpha >= log(rand())
+            new_params
+        else
+            xk
+        end
+    end
+
+    # display([walkers new_walkers])
+    return vals
+end
+
+function q(
+    proposal::Proposal{<:Emcee, <:Distribution}, 
+    t,
+    t_cond
+)
+    p = proposal.proposal
+    return sum(logpdf.(p(t_cond), t))
+end

--- a/src/mcmcchains-connect.jl
+++ b/src/mcmcchains-connect.jl
@@ -6,7 +6,7 @@ function AbstractMCMC.bundle_samples(
     model::DensityModel, 
     s::Metropolis, 
     N::Integer, 
-    ts::Vector,
+    ts::Vector{Transition},
     chain_type::Type{Chains}; 
     param_names=missing,
     kwargs...
@@ -16,7 +16,7 @@ function AbstractMCMC.bundle_samples(
 
     # Check if we received any parameter names.
     if ismissing(param_names)
-        param_names = ["Parameter $i" for i in 1:length(s.init_params)]
+        param_names = ["param_$i" for i in 1:length(s.init_params)]
     else
         # Deepcopy to be thread safe.
         param_names = deepcopy(param_names)
@@ -27,4 +27,41 @@ function AbstractMCMC.bundle_samples(
 
     # Bundle everything up and return a Chains struct.
     return Chains(vals, param_names, (internals=["lp"],))
+end
+
+function AbstractMCMC.bundle_samples(
+    rng::AbstractRNG, 
+    model::DensityModel, 
+    s::Metropolis, 
+    N::Integer, 
+    ts::Vector{<:EmceeTransition},
+    chain_type::Type{Chains}; 
+    param_names=missing,
+    kwargs...
+)
+    # return ts
+    vals = mapreduce(
+        t -> map(i -> vcat(ts[t].walkers[i].params, 
+                 ts[t].walkers[i].lp, t, i),
+                 1:length(ts[t].walkers)), 
+        vcat, 
+        1:length(ts))
+    
+    vals = Array(reduce(hcat, vals)')
+
+    # return vals
+
+    # Check if we received any parameter names.
+    if ismissing(param_names)
+        param_names = ["param_$i" for i in 1:length(ts[1].walkers[1].params)]
+    else
+        # Deepcopy to be thread safe.
+        param_names = deepcopy(param_names)
+    end
+
+    # Add the log density field to the parameter names.
+    push!(param_names, "lp", "iteration", "walker")
+
+    # Bundle everything up and return a Chains struct.
+    return Chains(vals, param_names, (internals=["lp", "iteration", "walker"],))
 end


### PR DESCRIPTION
This is an early implementation of the `emcee` sampler ([Python version](https://github.com/dfm/emcee)) for AdvancedMH. Currently only stretch steps are used.

```julia
using AdvancedMH, Distributions
using MCMCChains
using Random

Random.seed!(42)

dims = 5
means = [0.37454012, 0.95071431, 0.73199394, 0.59865848, 0.15601864]

cov = [0.50123328  -0.02919697  -0.31413411   0.04476438  -0.10623147;
       -0.02919697   0.71060761   0.08863136  -0.15006354  -0.1539235 ; 
       -0.31413411   0.08863136   0.29343271  -0.04202359   0.06292544; 
        0.04476438  -0.15006354  -0.04202359   0.11739352   0.15256884; 
       -0.10623147  -0.1539235    0.06292544   0.15256884   0.3957519 ;]

logprob(theta) = -0.5 * dot(theta - means, cov \ (theta - means))
model = DensityModel(logprob)

# Prior distribution.
pdist = MvNormal(5,1)

# Use 200 walkers and a stretch length of 2.0.
em = AdvancedMH.Emcee(2.0, 200)

# Make a proposal.
prop = Proposal(em, pdist)

# Construct the sampler.
spl = MetropolisHastings(prop)

chain = sample(model, spl, 10000; chain_type=Chains)
```

Result:

```
Object of type Chains, with data of type 2000000×8×1 Array{Float64,3}

Iterations        = 1:2000000
Thinning interval = 1
Chains            = 1
Samples per chain = 2000000
internals         = lp, iteration, walker
parameters        = param_5, param_2, param_4, param_1, param_3

2-element Array{ChainDataFrame,1}

Summary Statistics
  parameters    mean     std  naive_se    mcse          ess   r_hat
  ──────────  ──────  ──────  ────────  ──────  ───────────  ──────
     param_1  0.3764  0.4428    0.0003  0.0005  175572.8763  1.0000
     param_2  0.9569  0.5308    0.0004  0.0007  160540.1590  1.0001
     param_3  0.7303  0.3392    0.0002  0.0004  167943.2330  1.0000
     param_4  0.5976  0.2134    0.0002  0.0003  195118.0129  1.0000
     param_5  0.1527  0.3952    0.0003  0.0005  170851.6226  1.0000

Quantiles
  parameters     2.5%    25.0%   50.0%   75.0%   97.5%
  ──────────  ───────  ───────  ──────  ──────  ──────
     param_1  -0.5386   0.1210  0.3751  0.6315  1.2948
     param_2  -0.1402   0.6479  0.9581  1.2658  2.0520
     param_3   0.0272   0.5350  0.7305  0.9268  1.4299
     param_4   0.1575   0.4746  0.5964  0.7209  1.0397
     param_5  -0.6625  -0.0772  0.1508  0.3817  0.9719
```

# Todo

- [ ] Add `NamedTuple` support
- [ ] Consider making each walker its own MH sampler -- maybe more idiomatic
- [ ] Benchmark against common models. Does anyone have a good one to test?
- [ ] Commenting & docstrings
- [ ] Expand test suite