### PR TITLE
Add affine-invariant ensemble sampler

### DIFF
--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -102,5 +102,6 @@ end
 # Include inference methods.
 include("proposal.jl")
 include("mh-core.jl")
+include("emcee.jl")
 
 end # module AdvancedMH

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -8,7 +8,8 @@ using Requires
 import Random
 
 # Exports
-export MetropolisHastings, DensityModel, RWMH, StaticMH, StaticProposal, RandomWalkProposal
+export MetropolisHastings, DensityModel, RWMH, StaticMH, StaticProposal, 
+    RandomWalkProposal, Ensemble, StretchProposal
 
 # Reexports
 export sample, MCMCThreads, MCMCDistributed

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -15,10 +15,6 @@ export sample, MCMCThreads, MCMCDistributed
 
 # Abstract type for MH-style samplers. Needs better name? 
 abstract type MHSampler <: AbstractMCMC.AbstractSampler end
-abstract type ProposalStyle end
-
-struct RandomWalk <: ProposalStyle end
-struct Static <: ProposalStyle end
 
 # Define a model type. Stores the log density function and the data to 
 # evaluate the log density on.

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -14,8 +14,8 @@ export MetropolisHastings, DensityModel, RWMH, StaticMH, Proposal, Static, Rando
 using AbstractMCMC: sample, psample
 export sample, psample
 
-# Abstract type for MH-style samplers.
-abstract type Metropolis <: AbstractMCMC.AbstractSampler end
+# Abstract type for MH-style samplers. Needs better name? 
+abstract type AMH <: AbstractMCMC.AbstractSampler end
 abstract type ProposalStyle end
 
 struct RandomWalk <: ProposalStyle end
@@ -57,7 +57,7 @@ logdensity(model::DensityModel, t::Transition) = t.lp
 function AbstractMCMC.bundle_samples(
     rng::AbstractRNG, 
     model::DensityModel, 
-    s::Metropolis, 
+    s::AMH, 
     N::Integer,
     ts::Vector,
     chain_type::Type{Any}; 
@@ -70,7 +70,7 @@ end
 function AbstractMCMC.bundle_samples(
     rng::AbstractRNG, 
     model::DensityModel, 
-    s::Metropolis, 
+    s::AMH, 
     N::Integer, 
     ts::Vector,
     chain_type::Type{Vector{NamedTuple}}; 

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -15,7 +15,7 @@ using AbstractMCMC: sample, psample
 export sample, psample
 
 # Abstract type for MH-style samplers. Needs better name? 
-abstract type AMH <: AbstractMCMC.AbstractSampler end
+abstract type MHSampler <: AbstractMCMC.AbstractSampler end
 abstract type ProposalStyle end
 
 struct RandomWalk <: ProposalStyle end
@@ -57,7 +57,7 @@ logdensity(model::DensityModel, t::Transition) = t.lp
 function AbstractMCMC.bundle_samples(
     rng::Random.AbstractRNG, 
     model::DensityModel, 
-    s::AMH, 
+    s::MHSampler, 
     N::Integer,
     ts::Vector,
     chain_type::Type{Any}; 
@@ -70,7 +70,7 @@ end
 function AbstractMCMC.bundle_samples(
     rng::Random.AbstractRNG, 
     model::DensityModel, 
-    s::AMH, 
+    s::MHSampler, 
     N::Integer, 
     ts::Vector,
     chain_type::Type{Vector{NamedTuple}}; 

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -47,21 +47,16 @@ function propose(rng::Random.AbstractRNG, spl::Ensemble, model::DensityModel)
     return [propose(rng, mh_spl, model) for _ in 1:spl.n_walkers]
 end
 
-
-
 #
 # Every other proposal
 # 
 function propose(rng::Random.AbstractRNG, spl::Ensemble, model::DensityModel, walkers::Vector{W}) where {W<:Transition}
-    new_walkers = Vector{W}(undef, spl.n_walkers)
-    interval = 1:spl.n_walkers
+    new_walkers = similar(walkers)
 
-
-    nwalkers = spl.n_walkers
-    others = 1:(nwalkers - 1)
-    for i in interval
+    others = 1:(spl.n_walkers - 1)
+    for i in 1:spl.n_walkers
         walker = walkers[i]
-        idx = mod1(i + rand(rng, others), nwalkers)
+        idx = mod1(i + rand(rng, others), spl.n_walkers)
         other_walker = walkers[idx]
         new_walkers[i] = move(rng, spl, model, walker, other_walker)
     end
@@ -95,7 +90,7 @@ function move(
     alphamult = (n - 1) * log(z)
 
     # Make new parameters
-    y = walker.params + z .* (other_walker.params - walker.params)
+    y = @. walker.params + z * (other_walker.params - walker.params)
 
     # Construct a new walker
     new_walker = Transition(model, y)

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -1,97 +1,237 @@
-
-
-struct EmceeTransition{T<:Transition}
-    walkers :: Vector{T}
+struct Ensemble{D} <: AMH
+    n_walkers::Int
+    proposal::D
 end
 
-mutable struct Emcee{F<:Real} <: ProposalStyle
-    stretch_size :: F
-    num_walkers :: Int
+struct Walker{T<:Union{Vector,Real,NamedTuple},L<:Real}
+    params::T
+    lp::L
 end
 
+Walker(t::Transition) = Walker(t.params, t.lp)
+Walker(model::DensityModel, params) = Walker(params, logdensity(model, params))
+
+# Define the first step! function, which is called at the 
+# beginning of sampling. Return the initial parameter used
+# to define the sampler.
 function AbstractMCMC.step!(
     rng::AbstractRNG,
     model::DensityModel,
-    spl::MetropolisHastings,
+    spl::Ensemble,
+    N::Integer,
+    ::Nothing;
+    init_params = nothing,
+    kwargs...,
+)
+    if init_params === nothing
+        return propose(spl, model)
+    else
+        return Transition(model, init_params)
+    end
+end
+
+# Define the other step functions. Returns a Transition containing
+# either a new proposal (if accepted) or the previous proposal 
+# (if not accepted).
+function AbstractMCMC.step!(
+    rng::AbstractRNG,
+    model::DensityModel,
+    spl::Ensemble,
     ::Integer,
-    params_prev::EmceeTransition;
-    kwargs...
+    params_prev;
+    kwargs...,
 )
-    # Generate a new proposal.
-    params = propose(spl, model, params_prev)
-    return params
+    # Generate a new proposal. Accept/reject happens at proposal level.
+    return propose(spl, model, params_prev)
 end
 
-# Make a proposal from a distribution.
-function propose(
-    spl::MetropolisHastings{<:Proposal{<:Emcee}},
-    model::DensityModel
-)
-    proposal = propose(spl.proposal, model)
-    return EmceeTransition(map(p -> Transition(model, p), proposal))
+#
+# Initial proposal
+# 
+function propose(spl::Ensemble, model::DensityModel)
+    # Make the first proposal with a static draw from the prior.
+    static_prop = Proposal(Static(), spl.proposal.proposal)
+    mh_spl = MetropolisHastings(static_prop)
+    return map(x -> Walker(propose(mh_spl, model)), 1:spl.n_walkers)
 end
 
-function propose(
-    spl::MetropolisHastings{<:Proposal{<:Emcee}},
-    model::DensityModel,
-    t
-)
-    proposal = propose(spl.proposal, model, t)
-    return EmceeTransition(proposal)
-end
 
-function propose(
-    proposal::Proposal{<:Emcee, <:Distribution}, 
-    model::DensityModel
-)
-    g = map(i -> rand(proposal), 1:proposal.type.num_walkers)
-    return g
-end
 
-function propose(
-    proposal::Proposal{<:Emcee, <:AbstractArray{T, 2}}, 
-    model::DensityModel
-) where T
-    size(proposal.proposal, 2) == proposal.type.num_walkers || 
-        error("""Initial matrix must have n_walkers ($(proposal.type.num_walkers)) columns.
-        Provided matrix has $(size(proposal.proposal, 2)) columns.""")
-    return map(i -> proposal.proposal[:, i], 1:size(proposal.proposal, 2))
-end
+#
+# Every other proposal
+# 
+function propose(spl::Ensemble, model::DensityModel, walkers::Vector{W}) where {W<:Walker}
+    new_walkers = Vector{W}(undef, spl.n_walkers)
+    interval = 1:spl.n_walkers
 
-function q(
-    proposal::Proposal{<:Emcee, <:Distribution}, 
-    t,
-    t_cond
-)
-    return sum(logpdf(proposal, t.params - t_cond.params))
-end
-
-function propose(
-    proposal::Proposal{<:Emcee}, 
-    model::DensityModel,
-    t
-)
-    walkers = t.walkers
-    ns = length(walkers[1].params)
-    zs = ((proposal.type.stretch_size - 1.0) .* rand(proposal.type.num_walkers) .+ 1) .^ 2.0 ./ proposal.type.stretch_size
-    interval = collect(1:proposal.type.num_walkers)
-    partition = interval[1:div(proposal.type.num_walkers, 2)]
-    alphamult = (ns - 1) .* log.(zs)
-
-    vals = map(interval) do k
-        xk = walkers[k]
-        xj = walkers[rand(filter(z -> z != k, interval))]
-        z = zs[k]
-        y = xk.params + z .* (xj.params - xk.params)
-        new_params = Transition(model, y)
-        alpha = alphamult[k] + new_params.lp - xk.lp + q(proposal, xk, new_params) - q(proposal, new_params, xk)
-
-        if alpha >= log(rand())
-            new_params
-        else
-            xk
-        end
+    for i in interval
+        walker = walkers[i]
+        other_walker = rand(walkers[interval.!=i])
+        new_walkers[i] = move(spl, model, walker, other_walker)
     end
 
-    return vals
+    return new_walkers
+end
+
+
+#####################################
+# Basic stretch move implementation #
+#####################################
+struct Stretch{F<:AbstractFloat} <: ProposalStyle
+    stretch_length::F
+end
+
+Stretch() = Stretch(2.0)
+
+function move(
+    # spl::Ensemble,
+    spl::Ensemble{Proposal{T,P}},
+    model::DensityModel,
+    walker::Walker,
+    other_walker::Walker,
+) where {T<:Stretch,P}
+    # Calculate intermediate values
+    proposal = spl.proposal
+    n = length(walker.params)
+    a = proposal.type.stretch_length
+    z = ((a - 1.0) * rand() + 1.0)^2.0 / a
+    alphamult = (n - 1) * log(z)
+
+    # Make new parameters
+    y = walker.params + z .* (other_walker.params - walker.params)
+
+    # Construct a new walker
+    new_walker = Walker(model, y)
+
+    # Calculate accept/reject value.
+    alpha = alphamult + new_walker.lp - walker.lp
+
+    if alpha >= log(rand())
+        return new_walker
+    else
+        return walker
+    end
+end
+
+#########################
+# Elliptical slice step #
+#########################
+
+struct EllipticalSlice{E} <: ProposalStyle
+    ellipse::E
+end
+
+function move(
+    # spl::Ensemble,
+    spl::Ensemble{Proposal{T,P}},
+    model::DensityModel,
+    walker::Walker,
+    other_walker::Walker,
+) where {T<:EllipticalSlice,P}
+    # Calculate intermediate values
+    proposal = spl.proposal
+    n = length(walker.params)
+    nu = rand(proposal.type.ellipse)
+
+    u = rand()
+    y = walker.lp + log(u)
+
+    theta_min = 0.0
+    theta_max = 2.0*π
+    theta = rand(Uniform(theta_min, theta_max))
+
+    theta_min = theta - 2.0*π
+    theta_max = theta
+    
+    f = walker.params
+    while true
+        ctheta = cos(theta)
+        stheta = sin(theta)
+
+        f_prime = f .* ctheta + nu .* stheta
+
+        new_walker = Walker(model, f_prime)
+
+        if new_walker.lp > y
+            return new_walker
+        else
+            if theta < 0 
+                theta_min = theta
+            else
+                theta_max = theta
+            end
+
+            theta = rand(Uniform(theta_min, theta_max))
+        end
+    end 
+end
+
+#####################
+# Slice and stretch #
+#####################
+struct EllipticalSliceStretch{E, S<:Stretch} <: ProposalStyle
+    ellipse::E
+    stretch::S
+end
+
+EllipticalSliceStretch(e) = EllipticalSliceStretch(e, Stretch(2.0))
+
+function move(
+    # spl::Ensemble,
+    spl::Ensemble{Proposal{T,P}},
+    model::DensityModel,
+    walker::Walker,
+    other_walker::Walker,
+) where {T<:EllipticalSliceStretch,P}
+    # Calculate intermediate values
+    proposal = spl.proposal
+    n = length(walker.params)
+    nu = rand(proposal.type.ellipse)
+
+    # Calculate stretch step first
+    subspl = Ensemble(spl.n_walkers, Proposal(proposal.type.stretch, proposal.proposal))
+    walker = move(subspl, model, walker, other_walker)
+
+    u = rand()
+    y = walker.lp + log(u)
+
+    theta_min = 0.0
+    theta_max = 2.0*π
+    theta = rand(Uniform(theta_min, theta_max))
+
+    theta_min = theta - 2.0*π
+    theta_max = theta
+    
+    f = walker.params
+
+    i = 0
+    while true
+        i += 1
+        
+        ctheta = cos(theta)
+        stheta = sin(theta)
+        
+        f_prime = f .* ctheta + nu .* stheta
+
+        if i >100
+            @warn "Rejecting slice sample"
+            return walker
+        end
+
+        new_walker = Walker(model, f_prime)
+
+        # @info "Slice step" i f f_prime y new_walker.lp theta theta_max theta_min
+
+        if new_walker.lp > y
+            return new_walker
+        else
+            if theta < 0 
+                theta_min = theta
+            else
+                theta_max = theta
+            end
+
+            theta = rand(Uniform(theta_min, theta_max))
+        end
+    end 
 end

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -1,4 +1,4 @@
-struct Ensemble{D} <: AMH
+struct Ensemble{D} <: MHSampler
     n_walkers::Int
     proposal::D
 end
@@ -134,19 +134,16 @@ function move(
     nu = rand(proposal.type.ellipse)
 
     u = rand()
-    y = walker.lp + log(u)
+    y = walker.lp - Random.randexp()
 
-    theta_min = 0.0
-    theta_max = 2.0*π
-    theta = rand(Uniform(theta_min, theta_max))
+    theta = 2 * π * rand()
 
     theta_min = theta - 2.0*π
     theta_max = theta
     
     f = walker.params
     while true
-        ctheta = cos(theta)
-        stheta = sin(theta)
+        stheta, ctheta = sincos(theta)
 
         f_prime = f .* ctheta + nu .* stheta
 
@@ -161,7 +158,7 @@ function move(
                 theta_max = theta
             end
 
-            theta = rand(Uniform(theta_min, theta_max))
+            theta = theta_min + (theta_max - theta_min) * rand()
         end
     end 
 end
@@ -193,11 +190,9 @@ function move(
     walker = move(subspl, model, walker, other_walker)
 
     u = rand()
-    y = walker.lp + log(u)
+    y = walker.lp - Random.randexp()
 
-    theta_min = 0.0
-    theta_max = 2.0*π
-    theta = rand(Uniform(theta_min, theta_max))
+    theta = 2 * π * rand()
 
     theta_min = theta - 2.0*π
     theta_max = theta
@@ -208,15 +203,9 @@ function move(
     while true
         i += 1
         
-        ctheta = cos(theta)
-        stheta = sin(theta)
+        stheta, ctheta = sincos(theta)
         
         f_prime = f .* ctheta + nu .* stheta
-
-        if i >100
-            @warn "Rejecting slice sample"
-            return walker
-        end
 
         new_walker = Walker(model, f_prime)
 
@@ -231,7 +220,7 @@ function move(
                 theta_max = theta
             end
 
-            theta = rand(Uniform(theta_min, theta_max))
+            theta = theta_min + (theta_max - theta_min) * rand()
         end
     end 
 end

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -93,7 +93,6 @@ function propose(
         end
     end
 
-    # display([walkers new_walkers])
     return vals
 end
 

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -81,7 +81,6 @@ function propose(
     vals = map(interval) do k
         xk = walkers[k]
         xj = walkers[rand(filter(z -> z != k, interval))]
-        xj = walkers[rand(filter(z -> z != k, interval))]
         z = zs[k]
         y = xk.params + z .* (xj.params - xk.params)
         new_params = Transition(model, y)

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -1,0 +1,108 @@
+
+
+struct EmceeTransition{T<:Transition}
+    walkers :: Vector{T}
+end
+
+mutable struct Emcee{F<:Real} <: ProposalStyle
+    stretch_size :: F
+    num_walkers :: Int
+end
+
+function AbstractMCMC.step!(
+    rng::AbstractRNG,
+    model::DensityModel,
+    spl::MetropolisHastings,
+    ::Integer,
+    params_prev::EmceeTransition;
+    kwargs...
+)
+    # Generate a new proposal.
+    params = propose(spl, model, params_prev)
+    return params
+end
+
+# Make a proposal from a distribution.
+function propose(
+    spl::MetropolisHastings{<:Proposal{<:Emcee}},
+    model::DensityModel
+)
+    proposal = propose(spl.proposal, model)
+    return EmceeTransition(map(p -> Transition(model, p), proposal))
+end
+
+function propose(
+    spl::MetropolisHastings{<:Proposal{<:Emcee}},
+    model::DensityModel,
+    t
+)
+    proposal = propose(spl.proposal, model, t)
+    return EmceeTransition(proposal)
+end
+
+function propose(
+    proposal::Proposal{<:Emcee, <:Distribution}, 
+    model::DensityModel
+)
+    g = map(i -> rand(proposal), 1:proposal.type.num_walkers)
+    return g
+end
+
+function propose(
+    proposal::Proposal{<:Emcee, <:AbstractArray{T, 2}}, 
+    model::DensityModel
+) where T
+    size(proposal.proposal, 2) == proposal.type.num_walkers || 
+        error("""Initial matrix must have n_walkers ($(proposal.type.num_walkers)) columns.
+        Provided matrix has $(size(proposal.proposal, 2)) columns.""")
+    return map(i -> proposal.proposal[:, i], 1:size(proposal.proposal, 2))
+end
+
+function q(
+    proposal::Proposal{<:Emcee, <:Distribution}, 
+    t,
+    t_cond
+)
+    return sum(logpdf(proposal, t.params - t_cond.params))
+end
+
+function propose(
+    proposal::Proposal{<:Emcee}, 
+    model::DensityModel,
+    t
+)
+    walkers = t.walkers
+    ns = length(walkers[1].params)
+    zs = ((proposal.type.stretch_size - 1.0) .* rand(proposal.type.num_walkers) .+ 1) .^ 2.0 ./ proposal.type.stretch_size
+    interval = collect(1:proposal.type.num_walkers)
+    partition = interval[1:div(proposal.type.num_walkers, 2)]
+    alphamult = (ns - 1) .* log.(zs)
+
+    vals = map(interval) do k
+        xk = walkers[k]
+        xj = walkers[rand(filter(z -> z != k, interval))]
+        xj = walkers[rand(filter(z -> z != k, interval))]
+        z = zs[k]
+        y = xk.params + z .* (xj.params - xk.params)
+        new_params = Transition(model, y)
+        alpha = alphamult[k] + new_params.lp - xk.lp + q(proposal, xk, new_params) - q(proposal, new_params, xk)
+
+        if alpha >= log(rand())
+            new_params
+        else
+            xk
+        end
+    end
+
+    # display([walkers new_walkers])
+    return vals
+end
+
+function q(
+    proposal::Proposal{<:Emcee, <:Distribution}, 
+    t,
+    t_cond
+)
+    p = proposal.proposal
+    return sum(logpdf.(p(t_cond), t))
+end

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -95,12 +95,3 @@ function propose(
 
     return vals
 end
-
-function q(
-    proposal::Proposal{<:Emcee, <:Distribution}, 
-    t,
-    t_cond
-)
-    p = proposal.proposal
-    return sum(logpdf.(p(t_cond), t))
-end

--- a/src/mcmcchains-connect.jl
+++ b/src/mcmcchains-connect.jl
@@ -29,43 +29,6 @@ function AbstractMCMC.bundle_samples(
     return Chains(vals, param_names, (internals=["lp"],))
 end
 
-# function AbstractMCMC.bundle_samples(
-#     rng::Random.AbstractRNG, 
-#     model::DensityModel, 
-#     s::Ensemble, 
-#     N::Integer, 
-#     ts::Vector{<:Walker},
-#     chain_type::Type{Chains}; 
-#     param_names=missing,
-#     kwargs...
-# )
-#     # return ts
-#     vals = mapreduce(
-#         t -> map(i -> vcat(ts[t].walkers[i].params, 
-#                  ts[t].walkers[i].lp, t, i),
-#                  1:length(ts[t].walkers)), 
-#         vcat, 
-#         1:length(ts))
-    
-#     vals = Array(reduce(hcat, vals)')
-
-#     # return vals
-
-#     # Check if we received any parameter names.
-#     if ismissing(param_names)
-#         param_names = ["param_$i" for i in 1:length(ts[1].walkers[1].params)]
-#     else
-#         # Deepcopy to be thread safe.
-#         param_names = deepcopy(param_names)
-#     end
-
-#     # Add the log density field to the parameter names.
-#     push!(param_names, "lp", "iteration", "walker")
-
-#     # Bundle everything up and return a Chains struct.
-#     return Chains(vals, param_names, (internals=["lp", "iteration", "walker"],))
-# end
-
 function AbstractMCMC.bundle_samples(
     rng::Random.AbstractRNG, 
     model::DensityModel, 

--- a/src/mcmcchains-connect.jl
+++ b/src/mcmcchains-connect.jl
@@ -6,7 +6,7 @@ function AbstractMCMC.bundle_samples(
     model::DensityModel, 
     s::Metropolis, 
     N::Integer, 
-    ts::Vector,
+    ts::Vector{Transition},
     chain_type::Type{Chains}; 
     param_names=missing,
     kwargs...
@@ -16,7 +16,7 @@ function AbstractMCMC.bundle_samples(
 
     # Check if we received any parameter names.
     if ismissing(param_names)
-        param_names = ["Parameter $i" for i in 1:length(s.init_params)]
+        param_names = ["param_$i" for i in 1:length(s.init_params)]
     else
         # Deepcopy to be thread safe.
         param_names = deepcopy(param_names)
@@ -27,4 +27,41 @@ function AbstractMCMC.bundle_samples(
 
     # Bundle everything up and return a Chains struct.
     return Chains(vals, param_names, (internals=["lp"],))
+end
+
+function AbstractMCMC.bundle_samples(
+    rng::AbstractRNG, 
+    model::DensityModel, 
+    s::Metropolis, 
+    N::Integer, 
+    ts::Vector{<:EmceeTransition},
+    chain_type::Type{Chains}; 
+    param_names=missing,
+    kwargs...
+)
+    # return ts
+    vals = mapreduce(
+        t -> map(i -> vcat(ts[t].walkers[i].params, 
+                 ts[t].walkers[i].lp, t, i),
+                 1:length(ts[t].walkers)), 
+        vcat, 
+        1:length(ts))
+    
+    vals = Array(reduce(hcat, vals)')
+
+    # return vals
+
+    # Check if we received any parameter names.
+    if ismissing(param_names)
+        param_names = ["param_$i" for i in 1:length(ts[1].walkers[1].params)]
+    else
+        # Deepcopy to be thread safe.
+        param_names = deepcopy(param_names)
+    end
+
+    # Add the log density field to the parameter names.
+    push!(param_names, "lp", "iteration", "walker")
+
+    # Bundle everything up and return a Chains struct.
+    return Chains(vals, param_names, (internals=["lp", "iteration", "walker"],))
 end

--- a/src/mcmcchains-connect.jl
+++ b/src/mcmcchains-connect.jl
@@ -6,7 +6,7 @@ function AbstractMCMC.bundle_samples(
     model::DensityModel, 
     s::MHSampler, 
     N::Integer, 
-    ts::Vector{Transition},
+    ts,
     chain_type::Type{Chains}; 
     param_names=missing,
     kwargs...
@@ -29,45 +29,45 @@ function AbstractMCMC.bundle_samples(
     return Chains(vals, param_names, (internals=["lp"],))
 end
 
-function AbstractMCMC.bundle_samples(
-    rng::AbstractRNG, 
-    model::DensityModel, 
-    s::MHSampler, 
-    N::Integer, 
-    ts::Vector{<:EmceeTransition},
-    chain_type::Type{Chains}; 
-    param_names=missing,
-    kwargs...
-)
-    # return ts
-    vals = mapreduce(
-        t -> map(i -> vcat(ts[t].walkers[i].params, 
-                 ts[t].walkers[i].lp, t, i),
-                 1:length(ts[t].walkers)), 
-        vcat, 
-        1:length(ts))
+# function AbstractMCMC.bundle_samples(
+#     rng::Random.AbstractRNG, 
+#     model::DensityModel, 
+#     s::Ensemble, 
+#     N::Integer, 
+#     ts::Vector{<:Walker},
+#     chain_type::Type{Chains}; 
+#     param_names=missing,
+#     kwargs...
+# )
+#     # return ts
+#     vals = mapreduce(
+#         t -> map(i -> vcat(ts[t].walkers[i].params, 
+#                  ts[t].walkers[i].lp, t, i),
+#                  1:length(ts[t].walkers)), 
+#         vcat, 
+#         1:length(ts))
     
-    vals = Array(reduce(hcat, vals)')
+#     vals = Array(reduce(hcat, vals)')
 
-    # return vals
+#     # return vals
 
-    # Check if we received any parameter names.
-    if ismissing(param_names)
-        param_names = ["param_$i" for i in 1:length(ts[1].walkers[1].params)]
-    else
-        # Deepcopy to be thread safe.
-        param_names = deepcopy(param_names)
-    end
+#     # Check if we received any parameter names.
+#     if ismissing(param_names)
+#         param_names = ["param_$i" for i in 1:length(ts[1].walkers[1].params)]
+#     else
+#         # Deepcopy to be thread safe.
+#         param_names = deepcopy(param_names)
+#     end
 
-    # Add the log density field to the parameter names.
-    push!(param_names, "lp", "iteration", "walker")
+#     # Add the log density field to the parameter names.
+#     push!(param_names, "lp", "iteration", "walker")
 
-    # Bundle everything up and return a Chains struct.
-    return Chains(vals, param_names, (internals=["lp", "iteration", "walker"],))
-end
+#     # Bundle everything up and return a Chains struct.
+#     return Chains(vals, param_names, (internals=["lp", "iteration", "walker"],))
+# end
 
 function AbstractMCMC.bundle_samples(
-    rng::AbstractRNG, 
+    rng::Random.AbstractRNG, 
     model::DensityModel, 
     s::Ensemble, 
     N::Integer, 
@@ -100,5 +100,5 @@ function AbstractMCMC.bundle_samples(
     push!(param_names, "lp", "iteration", "walker")
 
     # Bundle everything up and return a Chains struct.
-    return Chains(vals, param_names, (internals=["lp", "iteration", "walker"],))
+    return Chains(vals, param_names, (internals=["lp", "iteration", "walker"],), sorted=true)
 end

--- a/src/mcmcchains-connect.jl
+++ b/src/mcmcchains-connect.jl
@@ -100,5 +100,5 @@ function AbstractMCMC.bundle_samples(
     push!(param_names, "lp", "iteration", "walker")
 
     # Bundle everything up and return a Chains struct.
-    return Chains(vals, param_names, (internals=["lp", "iteration", "walker"],), sorted=true)
+    return Chains(vals, param_names, (internals=["lp", "iteration", "walker"],))
 end

--- a/src/mcmcchains-connect.jl
+++ b/src/mcmcchains-connect.jl
@@ -4,7 +4,7 @@ import .MCMCChains: Chains
 function AbstractMCMC.bundle_samples(
     rng::Random.AbstractRNG, 
     model::DensityModel, 
-    s::AMH, 
+    s::MHSampler, 
     N::Integer, 
     ts::Vector{Transition},
     chain_type::Type{Chains}; 
@@ -32,7 +32,7 @@ end
 function AbstractMCMC.bundle_samples(
     rng::AbstractRNG, 
     model::DensityModel, 
-    s::AMH, 
+    s::MHSampler, 
     N::Integer, 
     ts::Vector{<:EmceeTransition},
     chain_type::Type{Chains}; 

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -41,7 +41,7 @@ used if `chain_type=Chains`.
 types are `chain_type=Chains` if `MCMCChains` is imported, or 
 `chain_type=StructArray` if `StructArrays` is imported.
 """
-mutable struct MetropolisHastings{D} <: Metropolis
+mutable struct MetropolisHastings{D} <: AMH
     proposal :: D
 end
 
@@ -185,7 +185,7 @@ function AbstractMCMC.step!(
     model::DensityModel,
     spl::MetropolisHastings,
     ::Integer,
-    params_prev::Transition;
+    params_prev;
     kwargs...
 )
     # Generate a new proposal.

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -41,7 +41,7 @@ used if `chain_type=Chains`.
 types are `chain_type=Chains` if `MCMCChains` is imported, or 
 `chain_type=StructArray` if `StructArrays` is imported.
 """
-mutable struct MetropolisHastings{D} <: AMH
+mutable struct MetropolisHastings{D} <: MHSampler
     proposal :: D
 end
 

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -41,8 +41,8 @@ used if `chain_type=Chains`.
 types are `chain_type=Chains` if `MCMCChains` is imported, or 
 `chain_type=StructArray` if `StructArrays` is imported.
 """
-mutable struct MetropolisHastings{D} <: MHSampler
-    proposal :: D
+struct MetropolisHastings{D} <: MHSampler
+    proposal::D
 end
 
 StaticMH(d) = MetropolisHastings(StaticProposal(d))
@@ -207,7 +207,7 @@ function AbstractMCMC.step!(
         + q(spl, params_prev, params) - q(spl, params, params_prev)
 
     # Decide whether to return the previous params or the new one.
-    if log(rand(rng)) < logα
+    if -Random.randexp(rng) < logα
         return params
     else
         return params_prev

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -203,8 +203,8 @@ function AbstractMCMC.step!(
     params = propose(rng, spl, model, params_prev)
 
     # Calculate the log acceptance probability.
-    logα = logdensity(model, params) - logdensity(model, params_prev) 
-        + q(spl, params_prev, params) - q(spl, params, params_prev)
+    logα = logdensity(model, params) - logdensity(model, params_prev) +
+        q(spl, params_prev, params) - q(spl, params, params_prev)
 
     # Decide whether to return the previous params or the new one.
     if -Random.randexp(rng) < logα

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -203,11 +203,11 @@ function AbstractMCMC.step!(
     params = propose(rng, spl, model, params_prev)
 
     # Calculate the log acceptance probability.
-    logα = logdensity(model, params) - logdensity(model, params_prev) + 
-        q(spl, params_prev, params) - q(spl, params, params_prev)
+    logα = logdensity(model, params) - logdensity(model, params_prev) 
+        + q(spl, params_prev, params) - q(spl, params, params_prev)
 
     # Decide whether to return the previous params or the new one.
-    if -Random.randexp(rng) < logα
+    if log(rand(rng)) < logα
         return params
     else
         return params_prev

--- a/src/structarray-connect.jl
+++ b/src/structarray-connect.jl
@@ -4,7 +4,7 @@ import .StructArrays: StructArray
 function AbstractMCMC.bundle_samples(
     rng::Random.AbstractRNG, 
     model::DensityModel, 
-    s::Metropolis, 
+    s::MHSampler, 
     N::Integer, 
     ts::Vector,
     chain_type::Type{StructArray}; 


### PR DESCRIPTION
This is an early implementation of the `emcee` sampler ([Python version](https://github.com/dfm/emcee)) for AdvancedMH. 

Supports three step types:

- Stretch (the original method from the paper)
- Slice (the walkers don't talk to eachother, so this is kind of a stupid implementation ATM
- Stretch + Slice, where a stretch step is completed first and then the ellipsoidal sampling occurs

```julia
using AdvancedMH, Distributions, AbstractMCMC
using MCMCChains
using Random
using LinearAlgebra

Random.seed!(42)

dims = 3

# Random matrices
means = rand(dims)

cov = 0.5 .- reshape(rand(dims ^ 2), (dims, dims))
cov = UpperTriangular(cov)
cov += cov' - Diagonal(diag(cov))
cov = cov*cov

function logprob(theta)
    -0.5 * dot(theta - means, cov \ (theta - means))
end
model = DensityModel(logprob)

# Run the three types of ensemble samplers
n_samples = 1000
n_walkers = 5

pdist = MvNormal(dims, 15)
spl_stretch = AdvancedMH.Ensemble(n_walkers, Proposal(AdvancedMH.Stretch(), pdist))
spl_slice = AdvancedMH.Ensemble(n_walkers, Proposal(AdvancedMH.EllipticalSlice(pdist), pdist))
spl_both = AdvancedMH.Ensemble(n_walkers, Proposal(AdvancedMH.EllipticalSliceStretch(pdist), pdist))

@time chain_stretch = sample(model, spl_stretch, n_samples; chain_type=Chains, progress=true)
@time chain_slice = sample(model, spl_slice, n_samples; chain_type=Chains, progress=true)
@time chain_both = sample(model, spl_both, n_samples; chain_type=Chains, progress=true)
```


# Todo

- [ ] Add `NamedTuple` support
- [ ] Consider making each walker its own MH sampler -- maybe more idiomatic
- [ ] Benchmark against common models. Does anyone have a good one to test?
- [ ] Commenting & docstrings
- [ ] Expand test suite