### PR TITLE
Account for breaking changes in AbstractMCMC

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.5.1"
+version = "0.6.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-AbstractMCMC = "0.4, 0.5, 1"
+AbstractMCMC = "1"
 Distributions = "0.20, 0.21, 0.22, 0.23"
 Requires = "1.0"
 julia = "1"

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -1,7 +1,7 @@
 module AdvancedMH
 
 # Import the relevant libraries.
-import AbstractMCMC
+using AbstractMCMC
 using Distributions
 using Requires
 
@@ -11,8 +11,7 @@ import Random
 export MetropolisHastings, DensityModel, RWMH, StaticMH, StaticProposal, RandomWalkProposal
 
 # Reexports
-using AbstractMCMC: sample, psample
-export sample, psample
+export sample, MCMCThreads, MCMCDistributed
 
 # Abstract type for MH-style samplers.
 abstract type Metropolis <: AbstractMCMC.AbstractSampler end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,12 +53,19 @@ using Test
         @test mean(chain2.σ) ≈ 1.0 atol=0.1
     end
 
-    if VERSION >= v"1.3"
-        @testset "psample" begin
-            spl1 = StaticMH([Normal(0,1), Normal(0, 1)])
-            chain1 = psample(model, spl1, 10000, 4; param_names=["μ", "σ"], chain_type=Chains)
-            @test mean(chain1["μ"].value) ≈ 0.0 atol=0.1
-            @test mean(chain1["σ"].value) ≈ 1.0 atol=0.1
+    @testset "parallel sampling" begin
+        spl1 = StaticMH([Normal(0,1), Normal(0, 1)])
+
+        chain1 = sample(model, spl1, MCMCDistributed(), 10000, 4;
+                        param_names=["μ", "σ"], chain_type=Chains)
+        @test mean(chain1["μ"].value) ≈ 0.0 atol=0.1
+        @test mean(chain1["σ"].value) ≈ 1.0 atol=0.1
+
+        if VERSION >= v"1.3"
+            chain2 = sample(model, spl1, MCMCThreads(), 10000, 4;
+                            param_names=["μ", "σ"], chain_type=Chains)
+            @test mean(chain2["μ"].value) ≈ 0.0 atol=0.1
+            @test mean(chain2["σ"].value) ≈ 1.0 atol=0.1
         end
     end
 


### PR DESCRIPTION
As I wrote in https://github.com/TuringLang/AdvancedMH.jl/pull/25#issuecomment-608649074,
> @cpfiffer I've thought about making a new release (I actually increased the version number to 0.5.1) but since AdvancedMH reexports psample that will lead to deprecation warnings if one uses psample. Should we release it nevertheless and then remove support for AbstractMCMC 0.4 and 0.5, remove the export and release 0.6 afterwards?

I think we might just skip 0.5.1 and release 0.6 immediately?