### PR TITLE
Fix parameter names when Transitions hold NamedTuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -84,7 +84,7 @@ function AbstractMCMC.bundle_samples(
     chain_type::Type{Vector{NamedTuple}};
     param_names=missing,
     kwargs...
-) where {T<:NamedTuple, L}
+)
     # If the element type of ts is NamedTuples, just use the names in the
     # struct.
 

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -58,7 +58,7 @@ function AbstractMCMC.bundle_samples(
     chain_type::Type{Vector{NamedTuple}};
     param_names=missing,
     kwargs...
-) where {T, L}
+)
     # Check if we received any parameter names.
     if ismissing(param_names)
         param_names = ["param_$i" for i in 1:length(keys(ts[1].params))]

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -51,7 +51,7 @@ logdensity(model::DensityModel, t::Transition) = t.lp
 
 # A basic chains constructor that works with the Transition struct we defined.
 function AbstractMCMC.bundle_samples(
-    ts::Vector{Transition{T, L}},
+    ts::Vector{<:Transition},
     model::DensityModel,
     sampler::MHSampler,
     state,

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -51,29 +51,39 @@ logdensity(model::DensityModel, t::Transition) = t.lp
 
 # A basic chains constructor that works with the Transition struct we defined.
 function AbstractMCMC.bundle_samples(
-    ts::Vector{<:Transition},
+    ts::Vector{Transition{T, L}},
     model::DensityModel,
     sampler::MHSampler,
     state,
     chain_type::Type{Vector{NamedTuple}};
     param_names=missing,
     kwargs...
-)
-    # Check if we received any parameter names.
-    if ismissing(param_names)
-        param_names = ["param_$i" for i in 1:length(keys(ts[1].params))]
+) where {T, L}
+    # If the element type of ts is NamedTuples, just use those names:
+    if T <: NamedTuple
+        # Extract NamedTuples
+        nts = map(x -> merge(x.params, (lp=x.lp,)), ts)
+
+        # Return em'
+        return nts
     else
-        # Deepcopy to be thread safe.
-        param_names = deepcopy(param_names)
+        # Otherwise, default to heuristics to infer parameter names.
+        # Check if we received any parameter names.
+        if ismissing(param_names)
+            param_names = ["param_$i" for i in 1:length(keys(ts[1].params))]
+        else
+            # Deepcopy to be thread safe.
+            param_names = deepcopy(param_names)
+        end
+
+        push!(param_names, "lp")
+
+        # Turn all the transitions into a vector-of-NamedTuple.
+        ks = tuple(Symbol.(param_names)...)
+        nts = [NamedTuple{ks}(tuple(t.params..., t.lp)) for t in ts]
+
+        return nts
     end
-
-    push!(param_names, "lp")
-
-    # Turn all the transitions into a vector-of-NamedTuple.
-    ks = tuple(Symbol.(param_names)...)
-    nts = [NamedTuple{ks}(tuple(t.params..., t.lp)) for t in ts]
-
-    return nts
 end
 
 function __init__()

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -77,7 +77,7 @@ function AbstractMCMC.bundle_samples(
 end
 
 function AbstractMCMC.bundle_samples(
-    ts::Vector{Transition{T, L}},
+    ts::Vector{<:Transition{<:NamedTuple}},
     model::DensityModel,
     sampler::MHSampler,
     state,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,11 @@ using Test
         c2 = sample(m2, MetropolisHastings(p2), 100; chain_type=Vector{NamedTuple})
         c3 = sample(m3, MetropolisHastings(p3), 100; chain_type=Vector{NamedTuple})
         c4 = sample(m4, MetropolisHastings(p4), 100; chain_type=Vector{NamedTuple})
+
+        @test keys(c1[1]) == (:param_1, :lp)
+        @test keys(c2[1]) == (:param_1, :param_2, :lp)
+        @test keys(c3[1]) == (:a, :b, :lp)
+        @test keys(c4[1]) == (:param_1, :lp)
     end
 
     @testset "Initial parameters" begin


### PR DESCRIPTION
Fixes the issue where `bundle_samples` was not using the information in a `NamedTuple` transition to return the correct parameter name from https://github.com/cscherrer/Soss.jl/issues/91.