### PR TITLE
Skipping the Hastings computation for symmetric proposals

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,10 @@ using Test
         spl1 = RWMH([Normal(0,1), Normal(0, 1)])
         spl2 = RWMH(MvNormal([0.0, 0.0], 1))
 
+        # Ensure that these are `SymmetricProposal`s.
+        @test spl1 isa AdvancedMH.MetropolisHastings{<:AdvancedMH.SymmetricProposal}
+        @test spl2 isa AdvancedMH.MetropolisHastings{<:AdvancedMH.SymmetricProposal}
+
         # Sample from the posterior.
         chain1 = sample(model, spl1, 100000; chain_type=StructArray, param_names=["μ", "σ"])
         chain2 = sample(model, spl2, 100000; chain_type=StructArray, param_names=["μ", "σ"])


### PR DESCRIPTION
This is an attempt to fix #41 so that the Hastings part of the Metropolis-Hastings log acceptance probability is not computed for symmetric proposals.

I separated out the computation from `AbstractMCMC.step`, and defined different behaviors for the ratio computation for different proposals. Basically, if the proposal is a (vector of) symmetric distribution, the Hastings part is not computed.

I added two tests to check if a sampler is indeed symmetric. I'm happy to add tests as directed. (I found it hard to test that the correct behavior was achieved because this merely skips the computation of something that evaluates to 0...)

Not sure if this is a good way to do this. An alternative solution might have been to add a filed in `MetropolisHastings` (e.g. `issymmetric::Bool`) to specify whether the proposal is symmetric. I'm open to suggestions.