### PR TITLE
Skipping the Hastings computation for symmetric proposals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -242,6 +242,8 @@ function AbstractMCMC.step(
 
     # Calculate the log acceptance probability.
     logα = logdensity(model, params) - logdensity(model, params_prev)
+
+    # Compute Hastings portion of ratio if proposal is not symmetric.
     if !is_symmetric_proposal(spl.proposal)
       logα += q(spl, params_prev, params) - q(spl, params, params_prev)
     end

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -242,7 +242,7 @@ function AbstractMCMC.step(
 
     # Calculate the log acceptance probability.
     logα = logdensity(model, params) - logdensity(model, params_prev)
-    if is_symmetric_proposal(spl.proposal)
+    if !is_symmetric_proposal(spl.proposal)
       logα += q(spl, params_prev, params) - q(spl, params, params_prev)
     end
 

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -194,37 +194,20 @@ end
 """
     is_symmetric_proposal(proposal)
 
-# Example:
-
-```julia
-using Distributions, AdvancedMH
-
-# Model definition.
-model = DensityModel(s -> logpdf(Normal(), s.x) + logpdf(Normal(5,.7), s.y))
-
-# Set up the proposal.
-p = (x=RandomWalkProposal(Normal(0,.5)), y=RandomWalkProposal(Normal(0,.5)))
-
-# Implementing this will skip the computation of the Hastings ratio.
-AdvancedMH.is_symmetric_proposal(proposal::typeof(p)) = true
-
-# Sample from the posterior with initial parameters.
-chain = sample(m1, MetropolisHastings(p), 100000; chain_type=Vector{NamedTuple})
-```
 """
-is_symmetric_proposal(proposal::P) where P = false
+is_symmetric_proposal(proposal) = false
 
 # The following univariate random walk proposals are symmetric.
-is_symmetric_proposal(proposal::RandomWalkProposal{<:Normal}) = true
-is_symmetric_proposal(proposal::RandomWalkProposal{<:MvNormal}) = true
-is_symmetric_proposal(proposal::RandomWalkProposal{<:TDist}) = true
-is_symmetric_proposal(proposal::RandomWalkProposal{<:Cauchy}) = true
+is_symmetric_proposal(::RandomWalkProposal{<:Normal}) = true
+is_symmetric_proposal(::RandomWalkProposal{<:MvNormal}) = true
+is_symmetric_proposal(::RandomWalkProposal{<:TDist}) = true
+is_symmetric_proposal(::RandomWalkProposal{<:Cauchy}) = true
 
 # The following multivariate random walk proposals are symmetric.
-is_symmetric_proposal(proposal::RandomWalkProposal{AbstractArray{<:Normal}}) = true
-is_symmetric_proposal(proposal::RandomWalkProposal{AbstractArray{<:MvNormal}}) = true
-is_symmetric_proposal(proposal::RandomWalkProposal{AbstractArray{<:TDist}}) = true
-is_symmetric_proposal(proposal::RandomWalkProposal{AbstractArray{<:Cauchy}}) = true
+is_symmetric_proposal(::RandomWalkProposal{<:AbstractArray{<:Normal}}) = true
+is_symmetric_proposal(::RandomWalkProposal{<:AbstractArray{<:MvNormal}}) = true
+is_symmetric_proposal(::RandomWalkProposal{<:AbstractArray{<:TDist}}) = true
+is_symmetric_proposal(::RandomWalkProposal{<:AbstractArray{<:Cauchy}}) = true
 
 # Define the other sampling steps.
 # Return a 2-tuple consisting of the next sample and the the next state.

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -192,7 +192,7 @@ function AbstractMCMC.step(
 end
 
 """
-    is_symmetric_proposal(proposal::P) where P
+    is_symmetric_proposal(proposal)
 
 # Example:
 

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -192,8 +192,15 @@ function AbstractMCMC.step(
 end
 
 """
-    is_symmetric_proposal(proposal)
+    is_symmetric_proposal(proposal)::Bool
 
+Implementing this for a custom proposal will allow `AbstractMCMC.step` to avoid
+computing the "Hastings" part of the Metropolis-Hasting log acceptance
+probability (if the proposal is indeed symmetric). By default,
+`is_symmetric_proposal(proposal)` returns `false`.  The user is responsible for
+determining whether a custom proposal distribution is indeed symmetric.  As
+noted in `MetropolisHastings`, `proposal` is a `Proposal`, `NamedTuple` of
+`Proposal`, or `Array{Proposal}` in the shape of your data.
 """
 is_symmetric_proposal(proposal) = false
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,6 +112,7 @@ using ForwardDiff
         # Set up the proposal.
         p1 = (x=RandomWalkProposal(Normal(0,.5)), y=RandomWalkProposal(Normal(0,.5)))
         AdvancedMH.is_symmetric_proposal(proposal::typeof(p1)) = true
+        @test AdvancedMH.is_symmetric_proposal(p1)
 
         # Sample from the posterior with initial parameters.
         chain1 = sample(m1, MetropolisHastings(p1), 100000; chain_type=Vector{NamedTuple})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,7 +104,24 @@ using ForwardDiff
 
         @test chain1[1].params == val
     end
-    
+
+    @testset "is_symmetric_proposal" begin
+        # Model definition.
+        m1 = DensityModel(s -> logpdf(Normal(), s.x) + logpdf(Normal(5,.7), s.y))
+
+        # Set up the proposal.
+        p1 = (x=RandomWalkProposal(Normal(0,.5)), y=RandomWalkProposal(Normal(0,.5)))
+        AdvancedMH.is_symmetric_proposal(proposal::typeof(p1)) = true
+
+        # Sample from the posterior with initial parameters.
+        chain1 = sample(m1, MetropolisHastings(p1), 100000; chain_type=Vector{NamedTuple})
+
+        @test mean(getindex.(chain1, :x)) ≈ 0 atol=0.05
+        @test mean(getindex.(chain1, :y)) ≈ 5 atol=0.05
+        @test std(getindex.(chain1, :x)) ≈ 1 atol=0.05
+        @test std(getindex.(chain1, :y)) ≈ .7 atol=0.05
+    end
+
     @testset "MALA" begin
         
         # Set up the sampler.

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,0 +1,4 @@
+# Define a (custom) Standard Normal distribution, for illustrative puspose.
+struct StandardNormal <: Distributions.ContinuousUnivariateDistribution end
+Distributions.logpdf(::StandardNormal, x::Real) = -(x ^ 2 + log(2 * pi)) / 2
+Distributions.rand(rng::AbstractRNG, ::StandardNormal) = randn(Random.GLOBAL_RNG)


### PR DESCRIPTION
This is a do-over of #45 for #41 which adds a method `is_symmmetric_proposal` whose behavior can be extended by users.