### PR TITLE
Add better method to convert Trandition{NamedTuple} to MCMCChains

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,20 @@ include("util.jl")
         end
     end
 
+    @testset "MCMCChains" begin
+        spl1 = StaticMH([Normal(0,1), Normal(0, 1)])
+        spl2 = MetropolisHastings((μ = StaticProposal(Normal(0,1)), σ = StaticProposal(Normal(0, 1))))
+
+        chain1 = sample(model, spl1, 10_000; param_names=["μ", "σ"], chain_type=Chains)
+        chain2 = sample(model, spl2, 10_000; chain_type=Chains)
+
+        @test mean(chain1["μ"]) ≈ 0.0 atol=0.1
+        @test mean(chain1["σ"]) ≈ 1.0 atol=0.1
+
+        @test mean(chain2["μ"]) ≈ 0.0 atol=0.1
+        @test mean(chain2["σ"]) ≈ 1.0 atol=0.1
+    end
+
     @testset "Proposal styles" begin
         m1 = DensityModel(x -> logpdf(Normal(x,1), 1.0))
         m2 = DensityModel(x -> logpdf(Normal(x[1], x[2]), 1.0))


### PR DESCRIPTION
Fixes https://github.com/cscherrer/Soss.jl/issues/91 by allowing AdvancedMH to handle `Transition{<:AbstractArray}` and `Transition{<:NamedTuple}` separately.