### PR TITLE
Add `logratio_proposal_density` and remove `is_symmetric_proposal`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.5.8"
+version = "0.6.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -8,8 +8,18 @@ using Requires
 import Random
 
 # Exports
-export MetropolisHastings, DensityModel, RWMH, StaticMH, StaticProposal, 
-    RandomWalkProposal, Ensemble, StretchProposal, MALA
+export
+    MetropolisHastings,
+    DensityModel,
+    RWMH,
+    StaticMH,
+    StaticProposal,
+    SymmetricStaticProposal,
+    RandomWalkProposal,
+    SymmetricRandomWalkProposal,
+    Ensemble,
+    StretchProposal,
+    MALA
 
 # Reexports
 export sample, MCMCThreads, MCMCDistributed

--- a/src/MALA.jl
+++ b/src/MALA.jl
@@ -45,6 +45,11 @@ function q(
     return q(spl.proposal(-t_cond.gradient), t.params, t_cond.params)
 end
 
+function logratio_proposal_density(
+    sampler::MALA{<:Proposal}, state::GradientTransition, candidate::GradientTransition
+)
+    return q(sampler, state, candidate) - q(sampler, candidate, state)
+end
 
 """
     logdensity_and_gradient(model::DensityModel, params)

--- a/src/proposal.jl
+++ b/src/proposal.jl
@@ -15,10 +15,6 @@ struct RandomWalkProposal{issymmetric,P} <: Proposal{P}
 end
 const SymmetricRandomWalkProposal{P} = RandomWalkProposal{true,P}
 
-is_symmetric_proposal(proposal) = false
-is_symmetric_proposal(::RandomWalkProposal{true}) = true
-is_symmetric_proposal(::StaticProposal{true}) = true
-
 RandomWalkProposal(proposal) = RandomWalkProposal{false}(proposal)
 function RandomWalkProposal{issymmetric}(proposal) where {issymmetric}
     return RandomWalkProposal{issymmetric,typeof(proposal)}(proposal)

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,4 +1,3 @@
 # Define a (custom) Standard Normal distribution, for illustrative puspose.
 struct StandardNormal <: Distributions.ContinuousUnivariateDistribution end
-Distributions.logpdf(::StandardNormal, x::Real) = -(x ^ 2 + log(2 * pi)) / 2
 Distributions.rand(rng::AbstractRNG, ::StandardNormal) = randn(Random.GLOBAL_RNG)

--- a/test/util.jl
+++ b/test/util.jl
@@ -1,3 +1,7 @@
-# Define a (custom) Standard Normal distribution, for illustrative puspose.
-struct StandardNormal <: Distributions.ContinuousUnivariateDistribution end
-Distributions.rand(rng::AbstractRNG, ::StandardNormal) = randn(Random.GLOBAL_RNG)
+# Define a custom Normal distribution, for illustrative puspose.
+struct CustomNormal{T<:Real} <: Distributions.ContinuousUnivariateDistribution
+    m::T
+end
+CustomNormal() = CustomNormal(0)
+
+Distributions.rand(rng::AbstractRNG, d::CustomNormal) = d.m + randn(rng)


### PR DESCRIPTION
Currently, there are some problems with symmetric proposals:
- evaluation of `q` is not skipped if an array of symmetric proposals is used (@mschauer noticed this)
- `Normal` etc. are only symmetric if the mean is zero which is not checked

In this PR, the first issue is addressed with a new `logratio_proposal_density` function that iterates over proposals and hence allows to skip the computation of the proposal densities for a subset of proposals. The second problem is resolved by adding a type parameter `issymmetric` to `RandomWalkProposal`: if it is `true`, the computation of the proposal densities is skipped and `logratio_proposal_density` returns `0`. The default value is `false` but users can improve performance by constructing the proposal with `RandomWalkProposal{true}` if it is actually symmetric. An advantage of this approach is also that it is easier to declare a proposal to be symmetric: currently, users commit type piracy if they implement `is_symmetric_proposal(::RandomWalkProposal{D}) = true` for common distributions `D`.

I was wondering if one should add this type parameter also to `StaticProposal` or even `Proposal`. I guess it could be useful e.g. also for the "random walk proposal" `StaticProposal(x -> Normal(x, 1))` (a bit weird that it's called static...).

On a side note, it seems that `q` could be removed completely and one could just implement `logratio_proposal_density` (BTW the name `q` is not very descriptive).