### PR TITLE
Adaptive Metropolis algorithm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.6.0"
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -4,6 +4,7 @@ module AdvancedMH
 using AbstractMCMC
 using Distributions
 using Requires
+using LinearAlgebra
 
 import Random
 
@@ -19,7 +20,9 @@ export
     SymmetricRandomWalkProposal,
     Ensemble,
     StretchProposal,
-    MALA
+    MALA,
+    AMProposal,
+    AMSampler
 
 # Reexports
 export sample, MCMCThreads, MCMCDistributed
@@ -120,5 +123,6 @@ end
 include("proposal.jl")
 include("mh-core.jl")
 include("emcee.jl")
+include("adaptivemetropolis.jl")
 
 end # module AdvancedMH

--- a/src/adaptivemetropolis.jl
+++ b/src/adaptivemetropolis.jl
@@ -1,0 +1,107 @@
+struct AMSampler{D} <: MHSampler
+    proposal::D
+end
+
+propose(spl::AMSampler, args...) = propose(Random.GLOBAL_RNG, spl, args...)
+
+function propose(rng::Random.AbstractRNG, spl::AMSampler{<:Proposal}, model::DensityModel)
+    proposal = propose(rng, spl.proposal, model)
+    return Transition(model, proposal)
+end
+
+function propose(rng::Random.AbstractRNG, spl::AMSampler{<:Proposal}, model::DensityModel,
+                 params_prev::Transition)
+    proposal = propose(rng, spl.proposal, model, params_prev.params)
+    return Transition(model, proposal)
+end
+
+function AbstractMCMC.step(rng::Random.AbstractRNG, model::DensityModel, spl::AMSampler;
+                           init_params=nothing, kwargs...)
+    if init_params === nothing
+        transition = propose(rng, spl, model)
+    else
+        transition = transition(spl, model, init_params)
+    end
+
+    trackstep(spl.proposal, transition)
+    return transition, transition
+end
+
+function AbstractMCMC.step(rng::Random.AbstractRNG, model::DensityModel, spl::AMSampler,
+                           params_prev::AbstractTransition; kwargs...)
+    # Generate a new proposal.
+    params = propose(rng, spl, model, params_prev)
+    
+    # Calculate the log acceptance probability.
+    logα = logdensity(model, params) - logdensity(model, params_prev) +
+        logratio_proposal_density(spl, params_prev, params)
+
+    # Decide whether to return the previous params or the new one.
+    if -Random.randexp(rng) < logα
+        trackstep(spl.proposal, params, Val(true))
+        return params, params
+   else
+        trackstep(spl.proposal, params_prev, Val(false))
+        return params_prev, params_prev
+    end
+end
+
+# Called when the first sample is drawn
+trackstep(proposal::Proposal, params::Transition) = nothing
+
+# Called when a new step is performed, the last argument determines if the step is an acceptance step
+trackstep(proposal::Proposal, params::Transition, 
+          ::Union{Val{true}, Val{false}}) = nothing
+
+# Simple Adaptive Metropolis Proposal
+# The proposal at each step is equal to a scalar multiple
+# of the posterior covariance plus a fixed, small covariance
+# matrix epsilon which is also used for initial exploration.
+mutable struct AMProposal <: Proposal{MvNormal}
+    epsilon::Symmetric
+    scalefactor::Float64
+    proposal::MvNormal
+    samplemean::AbstractArray
+    samplesqmean::AbstractMatrix
+    N::Int
+end
+
+function AMProposal(epsilon::AbstractMatrix, scalefactor=2.38^2 / size(epsilon, 1))
+    sym = Symmetric(epsilon)
+    proposal = MvNormal(zeros(size(sym, 1)), sym)
+    AMProposal(sym, scalefactor, proposal, mean(proposal), zeros(size(sym)...), 0)
+end
+
+function logratio_proposal_density(sampler::AMSampler, params_prev::Transition, params::Transition)
+    return logratio_proposal_density(sampler.proposal, params_prev.params, params.params)
+end
+
+logratio_proposal_density(::AMProposal, params_prev, params) = 0
+
+function trackstep(proposal::AMProposal, trans::Transition)
+    proposal.samplemean = copy(trans.params)
+    proposal.samplesqmean = trans.params * trans.params'
+    proposal.proposal = MvNormal(zeros(size(proposal.samplemean)), proposal.epsilon)
+    proposal.N = 1
+end
+
+function trackstep(proposal::AMProposal, trans::Transition, ::Union{Val{true}, Val{false}})
+    proposal.samplemean = (proposal.samplemean .* proposal.N .+ trans.params) ./ (proposal.N + 1)
+
+    proposal.samplesqmean = (proposal.samplesqmean .* proposal.N + trans.params * trans.params') ./ 
+                             (proposal.N + 1)
+
+    samplecov = proposal.samplesqmean .- proposal.samplemean * proposal.samplemean'
+    prop_cov = proposal.scalefactor .* samplecov
+    proposal.proposal = MvNormal(mean(proposal.proposal), prop_cov .+ proposal.epsilon)
+    proposal.N += 1
+end
+
+function propose(rng::Random.AbstractRNG, p::AMProposal, ::DensityModel)
+    return rand(rng, p.proposal)
+end
+
+function propose(rng::Random.AbstractRNG, p::AMProposal, ::DensityModel, t)
+    return t + rand(rng, p.proposal)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,18 @@ include("util.jl")
     # Construct a DensityModel.
     model = DensityModel(density)
 
+    @testset "AdaptiveMH" begin
+        # Set up our sampler with initial parameters.
+        spl = AMSampler(AMProposal([0.01 0. ; 0. 0.01]))
+
+        # Sample from the posterior.
+        chain = sample(model, spl, 100000; chain_type=StructArray, param_names=["μ", "σ"])
+
+        # chn_mean ≈ dist_mean atol=atol_v
+        @test mean(chain.μ) ≈ 0.0 atol=0.1
+        @test mean(chain.σ) ≈ 1.0 atol=0.1
+    end
+
     @testset "StaticMH" begin
         # Set up our sampler with initial parameters.
         spl1 = StaticMH([Normal(0,1), Normal(0, 1)])
@@ -207,5 +219,4 @@ include("util.jl")
     end
 
     @testset "EMCEE" begin include("emcee.jl") end
-  
 end


### PR DESCRIPTION
I've implemented a simple version of the standard AM algorithm as a small extension to #39 (this PR is independent of #39). The pull request features a multivariate Gaussian proposal which uses a rescaled version of the posterior covariance (Haario et al.'s famous 2.38 rule) + a small epsilon term for positive-definiteness and initial exploration. In order to update the proposal I had to create a new sampler class, `AMSampler`, which is basically `MetropolisHastings` but updates the proposal at each sampling step via the `trackstep` function. The default implementation of `trackstep` does nothing.

The update mechanism is slightly different from that in #39: this one performs adaptation in `AbstractMCMC.step` whereas #39 does it in `propose`. I think the new `AMSampler` class should be able to handle both, and since it consists of minimal modifications to the original `MetropolisHastings` it could provide a general interface for adaptive MH algorithms.

Notes:
- Proposals are shared between threads - how can this be changed? 
- I haven't implemented all overloads of `propose` for `AMSampler` but this should not be an issue.
- This PR would benefit from #38 to make the `trackstep` interface more uniform.
- The test example is minimal, I would welcome any suggestions!