### PR TITLE
Generally support container of proposals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -3,23 +3,8 @@ struct Ensemble{D} <: MHSampler
     proposal::D
 end
 
-# Define the first sampling step.
-# Return a 2-tuple consisting of the initial sample and the initial state.
-# In this case they are identical.
-function AbstractMCMC.step(
-    rng::Random.AbstractRNG,
-    model::DensityModel,
-    spl::Ensemble;
-    init_params = nothing,
-    kwargs...,
-)
-    if init_params === nothing
-        transitions = propose(rng, spl, model)
-    else
-        transitions = [Transition(model, x) for x in init_params]
-    end
-
-    return transitions, transitions
+function transition(sampler::Ensemble, model::DensityModel, params)
+    return [Transition(model, x) for x in params]
 end
 
 # Define the other sampling steps.

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -98,9 +98,9 @@ function AbstractMCMC.step(
     candidate = propose(rng, sampler, model, transition_prev)
 
     # Calculate the log acceptance probability and the log density of the candidate.
-    logα, logdensity_candidate = logacceptance_logdensity(
-        sampler, model, transition_prev, candidate
-    )
+    logdensity_candidate = logdensity(model, candidate)
+    logα = logdensity_candidate - logdensity(model, transition_prev) +
+        logratio_proposal_density(sampler, transition_prev, candidate)
 
     # Decide whether to return the previous params or the new one.
     transition = if -Random.randexp(rng) < logα
@@ -110,18 +110,6 @@ function AbstractMCMC.step(
     end
 
     return transition, transition
-end
-
-function logacceptance_logdensity(
-    sampler::MHSampler,
-    model::DensityModel,
-    transition_prev::AbstractTransition,
-    candidate,
-)
-    logdensity_candidate = logdensity(model, candidate)
-    logα = logdensity_candidate - logdensity(model, transition_prev) +
-        logratio_proposal_density(sampler, transition_prev, candidate)
-    return logα, logdensity_candidate
 end
 
 function logratio_proposal_density(

--- a/src/mh-core.jl
+++ b/src/mh-core.jl
@@ -69,16 +69,12 @@ transition(model, params) = Transition(model, params)
 function AbstractMCMC.step(
     rng::Random.AbstractRNG,
     model::DensityModel,
-    spl::MHSampler;
+    sampler::MHSampler;
     init_params=nothing,
     kwargs...
 )
-    if init_params === nothing
-        transition = propose(rng, spl, model)
-    else
-        transition = AdvancedMH.transition(spl, model, init_params)
-    end
-
+    params = init_params === nothing ? propose(rng, sampler, model) : init_params
+    transition = AdvancedMH.transition(sampler, model, params)
     return transition, transition
 end
 

--- a/src/proposal.jl
+++ b/src/proposal.jl
@@ -125,6 +125,55 @@ function q(
     return q(proposal(t_cond), t, t_cond)
 end
 
+####################
+# Multiple proposals
+####################
+
+function propose(
+    rng::Random.AbstractRNG,
+    proposals::AbstractArray{<:Proposal},
+    model::DensityModel,
+)
+    return map(proposals) do proposal
+        return propose(rng, proposal, model)
+    end
+end
+function propose(
+    rng::Random.AbstractRNG,
+    proposals::AbstractArray{<:Proposal},
+    model::DensityModel,
+    ts,
+)
+    return map(proposals, ts) do proposal, t
+        return propose(rng, proposal, model, t)
+    end
+end
+
+@generated function propose(
+    rng::Random.AbstractRNG,
+    proposals::NamedTuple{names},
+    model::DensityModel,
+) where {names}
+    isempty(names) && return :(NamedTuple())
+    expr = Expr(:tuple)
+    expr.args = Any[:($name = propose(rng, proposals.$name, model)) for name in names]
+    return expr
+end
+
+@generated function _propose(
+    rng::Random.AbstractRNG,
+    proposal::NamedTuple{names},
+    model::DensityModel,
+    ts,
+) where {names}
+    isempty(names) && return :(NamedTuple())
+    expr = Expr(:tuple)
+    expr.args = Any[
+        :($name = propose(rng, proposals.$name, model, ts.$name)) for name in names
+    ]
+    return expr
+end
+
 """
     logratio_proposal_density(proposal, state, candidate)
 

--- a/src/proposal.jl
+++ b/src/proposal.jl
@@ -160,9 +160,9 @@ end
     return expr
 end
 
-@generated function _propose(
+@generated function propose(
     rng::Random.AbstractRNG,
-    proposal::NamedTuple{names},
+    proposals::NamedTuple{names},
     model::DensityModel,
     ts,
 ) where {names}


### PR DESCRIPTION
This PR addresses https://github.com/TuringLang/AdvancedMH.jl/issues/38#issuecomment-848796003 (no implicit construction of `Transition` and computation of the log density when generating the proposal) and https://github.com/TuringLang/AdvancedMH.jl/issues/53 (first class support for containers of proposals).

Currently, the latter is only supported if the proposals are part of `MHSampler`. Moreover, I imagine this allows us to remove support for `Proposal`s which itself include an array of proposals in a second step.