### PR TITLE
Fix Chains output for scalar parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/mcmcchains-connect.jl
+++ b/src/mcmcchains-connect.jl
@@ -2,7 +2,7 @@ import .MCMCChains: Chains
 
 # A basic chains constructor that works with the Transition struct we defined.
 function AbstractMCMC.bundle_samples(
-    ts::Vector{<:Transition{<:AbstractArray}},
+    ts::Vector{<:AbstractTransition},
     model::DensityModel,
     sampler::MHSampler,
     state,
@@ -63,7 +63,7 @@ function AbstractMCMC.bundle_samples(
 end
 
 function AbstractMCMC.bundle_samples(
-    ts::Vector{<:Vector{<:Transition}},
+    ts::Vector{<:Vector{<:AbstractTransition}},
     model::DensityModel,
     sampler::Ensemble,
     state,

--- a/src/structarray-connect.jl
+++ b/src/structarray-connect.jl
@@ -2,7 +2,7 @@ import .StructArrays: StructArray
 
 # A basic chains constructor that works with the Transition struct we defined.
 function AbstractMCMC.bundle_samples(
-    ts,
+    ts::Vector{<:AbstractTransition},
     model::DensityModel,
     sampler::MHSampler,
     state,


### PR DESCRIPTION
Currently it is not possible to obtain a `Chains` object when one samples a model with a single parameter (instead the default dispatch of `bundle_samples` is used). This PR fixes the issue.