### PR TITLE
Add parameter names to name_map in call to Chains constructor

### DIFF
--- a/src/mcmcchains-connect.jl
+++ b/src/mcmcchains-connect.jl
@@ -23,12 +23,10 @@ function AbstractMCMC.bundle_samples(
         param_names = Symbol.(param_names)
     end
 
-    # Add the log density field to the parameter names.
-    push!(param_names, :lp)
-
     # Bundle everything up and return a Chains struct.
     return Chains(
-        vals, param_names, (internals = [:lp],); start=discard_initial + 1, thin=thinning,
+        vals, vcat(param_names, [:lp]), (parameters = param_names, internals = [:lp],);
+        start=discard_initial + 1, thin=thinning,
     )
 end
 
@@ -66,7 +64,8 @@ function AbstractMCMC.bundle_samples(
 
     # Bundle everything up and return a Chains struct.
     return Chains(
-        vals, param_names, (internals = [:lp],); start=discard_initial + 1, thin=thinning,
+        vals, param_names, (parameters = param_names, internals = [:lp]);
+        start=discard_initial + 1, thin=thinning,
     )
 end
 
@@ -106,11 +105,9 @@ function AbstractMCMC.bundle_samples(
         param_names = Symbol.(param_names)
     end
 
-    # Add the log density field to the parameter names.
-    push!(param_names, :lp)
-
     # Bundle everything up and return a Chains struct.
     return Chains(
-        vals, param_names, (internals = [:lp],); start=discard_initial + 1, thin=thinning,
+        vals, vcat(param_names, [:lp]), (parameters = param_names, internals = [:lp]);
+        start=discard_initial + 1, thin=thinning,
     )
 end


### PR DESCRIPTION
This pull request ensures that if `chain = sample(...; chain_type=Chains)`, then `chain.name_map[:parameters]` and hence `names(chain, :parameters)` have the parameter names in the correct order.

Under the old behavior, the `Chains` [constructor](https://github.com/TuringLang/MCMCChains.jl/blob/master/src/chains.jl#L30-L31) is called with `parameter_names = param_names` and `name_map = (internals = [:lp],)`. [This results](https://github.com/TuringLang/MCMCChains.jl/blob/master/src/chains.jl#L59-L70) in all of `param_names` being added to the unordered `unassigned::Set{Symbol}`, and then `(parameters = unassigned,)` is appended to `name_map`. Finally, `names(chain)` basically references the correctly ordered `param_names`, while `names(chain, :parameters)` references the incorrectly ordered `name_map`.

As an example, suppose we want to estimate the mean and variance of a 5-dimensional standard multivariate normal distribution:

```julia
using AdvancedMH, MCMCChains
using Distributions, LinearAlgebra

data = rand(MvNormal(diagm(ones(5))), 300)
insupport(θ) = all(θ[6:10] .>= 0)
dist(θ) = MvNormal(θ[1:5], diagm(θ[6:10]))
density(θ) = insupport(θ) ? sum(logpdf(dist(θ), data)) : -Inf
model = DensityModel(density)

chain = sample(
    model, StaticMH(fill(Normal(0,1), 10)), 1_000;
    param_names=vcat(["μ[$i]" for i in 1:5], ["σ2[$i]" for i in 1:5]),
    chain_type=Chains
)
```

Old behavior:

```julia
julia> names(chain) # correctly ordered
11-element Array{Symbol,1}:
 Symbol("μ[1]")
 Symbol("μ[2]")
 Symbol("μ[3]")
 Symbol("μ[4]")
 Symbol("μ[5]")
 Symbol("σ2[1]")
 Symbol("σ2[2]")
 Symbol("σ2[3]")
 Symbol("σ2[4]")
 Symbol("σ2[5]")
 :lp

julia> names(chain, :parameters) # incorrectly ordered
10-element Array{Symbol,1}:
 Symbol("μ[1]")
 Symbol("μ[4]")
 Symbol("σ2[4]")
 Symbol("μ[2]")
 Symbol("μ[3]")
 Symbol("σ2[1]")
 Symbol("σ2[5]")
 Symbol("σ2[3]")
 Symbol("μ[5]")
 Symbol("σ2[2]")

julia> chain.name_map # incorrectly ordered
(parameters = [Symbol("μ[1]"), Symbol("μ[4]"), Symbol("σ2[4]"), Symbol("μ[2]"), Symbol("μ[3]"), Symbol("σ2[1]"), Symbol("σ2[5]"), Symbol("σ2[3]"), Symbol("μ[5]"), Symbol("σ2[2]")], internals = [:lp])
```

New behavior:

```julia
julia> names(chain) # correctly ordered
11-element Array{Symbol,1}:
 Symbol("μ[1]")
 Symbol("μ[2]")
 Symbol("μ[3]")
 Symbol("μ[4]")
 Symbol("μ[5]")
 Symbol("σ2[1]")
 Symbol("σ2[2]")
 Symbol("σ2[3]")
 Symbol("σ2[4]")
 Symbol("σ2[5]")
 :lp

julia> names(chain, :parameters) # correctly ordered
10-element Array{Symbol,1}:
 Symbol("μ[1]")
 Symbol("μ[2]")
 Symbol("μ[3]")
 Symbol("μ[4]")
 Symbol("μ[5]")
 Symbol("σ2[1]")
 Symbol("σ2[2]")
 Symbol("σ2[3]")
 Symbol("σ2[4]")
 Symbol("σ2[5]")

julia> chain.name_map # correctly ordered
(parameters = [Symbol("μ[1]"), Symbol("μ[2]"), Symbol("μ[3]"), Symbol("μ[4]"), Symbol("μ[5]"), Symbol("σ2[1]"), Symbol("σ2[2]"), Symbol("σ2[3]"), Symbol("σ2[4]"), Symbol("σ2[5]")], internals = [:lp])
```

Thanks in advance!