### PR TITLE
Remove type restriction of log density function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -33,18 +33,18 @@ abstract type AbstractTransition end
 # Define a model type. Stores the log density function and the data to 
 # evaluate the log density on.
 """
-    DensityModel{F<:Function} <: AbstractModel
+    DensityModel{F} <: AbstractModel
 
 `DensityModel` wraps around a self-contained log-liklihood function `logdensity`.
 
 Example:
 
 ```julia
-l
-DensityModel
+l(x) = logpdf(Normal(), x)
+DensityModel(l)
 ```
 """
-struct DensityModel{F<:Function} <: AbstractMCMC.AbstractModel
+struct DensityModel{F} <: AbstractMCMC.AbstractModel
     logdensity :: F
 end
 


### PR DESCRIPTION
This PR removes the type restriction of the log density function in `DensityModel`.

It feels a bit restrictive and makes it impossible to use e.g. callable structs - such as `Turing.LogDensityFunction`.