### PR TITLE
Fix Emcee

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/emcee.jl
+++ b/src/emcee.jl
@@ -44,11 +44,13 @@ function propose(
 )
     new_walkers = similar(walkers)
 
-    others = 1:(spl.n_walkers - 1)
-    for i in 1:spl.n_walkers
+    n_walkers = spl.n_walkers
+    uniform_sampler = Random.Sampler(rng, 1:(n_walkers - 1))
+
+    for i in 1:n_walkers
         walker = walkers[i]
-        idx = mod1(i + rand(rng, others), spl.n_walkers)
-        other_walker = walkers[idx]
+        idx = mod1(i + rand(rng, uniform_sampler), n_walkers)
+        other_walker = idx < i ? new_walkers[idx] : walkers[idx]
         new_walkers[i] = move(rng, spl, model, walker, other_walker)
     end
 


### PR DESCRIPTION
Should fix #69 if I understand correctly. In contrast to the suggestion in the issue, the `copy` of the previous walkers/transitions is avoided. `similar` should be faster than `copy` and avoid problems with shallow copies of nested structures.