### PR TITLE
Use `Random.default_rng()` instead of `Random.GLOBAL_RNG`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/proposal.jl
+++ b/src/proposal.jl
@@ -21,7 +21,7 @@ function RandomWalkProposal{issymmetric}(proposal) where {issymmetric}
 end
 
 # Random draws
-Base.rand(p::Proposal, args...) = rand(Random.GLOBAL_RNG, p, args...)
+Base.rand(p::Proposal, args...) = rand(Random.default_rng(), p, args...)
 Base.rand(rng::Random.AbstractRNG, p::Proposal{<:Distribution}) = rand(rng, p.proposal)
 function Base.rand(rng::Random.AbstractRNG, p::Proposal{<:AbstractArray})
     return map(x -> rand(rng, x), p.proposal)


### PR DESCRIPTION
`Random.GLOBAL_RNG` exists for backward compatibility but `Random.default_rng()` should be used nowadays (see, e.g., the docs for Julia 1.9: https://docs.julialang.org/en/v1.9.0-rc1/stdlib/Random/) and has even performance benefits (at least I remember one recent issue in base where this was pointed out). It has existed since at least Julia 1.3.