### PR TITLE
Fix CompatHelper directories

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -26,7 +26,7 @@ jobs:
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
-          CompatHelper.main(; subdirs = ["", "test"], bump_version=true)
+          CompatHelper.main(; subdirs = ["", "docs"], bump_version=true)
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #99.

Manual CompatHelper run with this PR: https://github.com/TuringLang/AdvancedMH.jl/actions/runs/10158674464/job/28091239744