### PR TITLE
Fixed method ambiguity for `MALA`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AdvancedMH"
 uuid = "5b7e9947-ddc0-4b3f-9b55-0d8042f74170"
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/MALA.jl
+++ b/src/MALA.jl
@@ -20,7 +20,7 @@ end
 
 logdensity(model::DensityModelOrLogDensityModel, t::GradientTransition) = t.lp
 
-propose(rng::Random.AbstractRNG, ::MALA, model) = error("please specify initial parameters")
+propose(::Random.AbstractRNG, ::MALA, ::DensityModelOrLogDensityModel) = error("please specify initial parameters")
 function transition(sampler::MALA, model::DensityModelOrLogDensityModel, params, accepted)
     return GradientTransition(params, logdensity_and_gradient(model, params)..., accepted)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,6 +271,15 @@ include("util.jl")
             σ² = 1e-3
             spl1 = MALA(x -> MvNormal((σ² / 2) .* x, σ² * I))
 
+            # Without `initial_params` this should error.
+            @test_throws ErrorException sample(
+                model, spl1, 1000;
+                chain_type=StructArray,
+                param_names=["μ", "σ"],
+                discard_initial=100,
+                progress=false
+            )
+
             # Sample from the posterior with initial parameters.
             chain1 = sample(
                 model, spl1, 1000;


### PR DESCRIPTION
If we forget to pass initial parameters to `MALA`, we encounter

https://github.com/TuringLang/AdvancedMH.jl/blob/fb7e87280fd5f1ad44aaca4889d8bcd48cb739e7/src/MALA.jl#L23

which is currently causing method ambiguities.

I've added both a fix + explicit testing of this scenario.