### PR TITLE
Implementation of Robust Adaptive Metropolis

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,8 @@
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 
 [compat]
 Documenter = "1"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -12,3 +12,9 @@ MetropolisHastings
 ```@docs
 DensityModel
 ```
+
+## Samplers
+
+```@docs
+RAM
+```

--- a/src/AdvancedMH.jl
+++ b/src/AdvancedMH.jl
@@ -160,4 +160,8 @@ include("mh-core.jl")
 include("emcee.jl")
 include("MALA.jl")
 
+include("RobustAdaptiveMetropolis.jl")
+using .RobustAdaptiveMetropolis
+export RAM
+
 end # module AdvancedMH


### PR DESCRIPTION
This PR introduces a simple implementation of *Robust Adaptive Metropolis* (RAM) that I have lying around.

This makes use of the more recent `AbstractMCMC.step_warmup`, which is meant to be used for exactly adaptation scenarios like this. The number of adaptation steps is therefore specified by `num_warmup` passed to `sample`.

Note that there have been a few previous attempts at adding adaptive MH samplers to AdvancdeMH.jl, but they've all "died out" as the complexity of adding such functionality to the existing "interface" is somewhat complicated. I would suggest we merge this as is (as I don't have enough time to push this to 100%), and then we later PRs can deal with either extending this to be more general and / or integrate it with the existing "interface".