### PR TITLE
Suggested minor correction to the low rank cholesky update term in RAM

### DIFF
--- a/src/RobustAdaptiveMetropolis.jl
+++ b/src/RobustAdaptiveMetropolis.jl
@@ -160,7 +160,7 @@ function ram_adapt(
     S = state.S
     # TODO: Make this configurable by defining a more general path.
     η = state.iteration^(-sampler.γ)
-    ΔS = (η * abs(Δα)) * S * U / LinearAlgebra.norm(U)
+    ΔS = sqrt(η * abs(Δα)) * S * U / LinearAlgebra.norm(U)
     # TODO: Maybe do in-place and then have the user extract it with a callback if they really want it.
     S_new = if sign(Δα) == 1
         # One rank update.


### PR DESCRIPTION
In the low rank update in linear algebra the terms are of the form $M = SS' + zz'$ but in the paper Vihola (2011) https://arxiv.org/pdf/1011.4381 the equation is split into the terms $M = SS' + a\tilde{z}\tilde{z}'$ so we shouldredefine $z \coloneqq \sqrt(a)\tilde{z}$ rather than as currently in the code $z \coloneqq a\tilde{z}$.

Fixes #113.